### PR TITLE
Drop python 2.6.9 due to issues with urllib3 ssl

### DIFF
--- a/cookbooks/travis_ci_mega/attributes/default.rb
+++ b/cookbooks/travis_ci_mega/attributes/default.rb
@@ -71,7 +71,6 @@ override['nodejs']['default'] = '4.0.0'
 
 override['python']['pyenv']['pythons'] = %w(
   2.7.10
-  2.6.9
   3.2.6
   3.3.6
   3.4.3
@@ -80,7 +79,6 @@ override['python']['pyenv']['pythons'] = %w(
   pypy3-2.4.0
 )
 override['python']['pyenv']['aliases'] = {
-  '2.6.9' => %w(2.6),
   '2.7.10' => %w(2.7),
   '3.2.6' => %w(3.2),
   '3.3.6' => %w(3.3),


### PR DESCRIPTION
See https://urllib3.readthedocs.org/en/latest/security.html#insecureplatformwarning