### PR TITLE
Set more job board tags per image

### DIFF
--- a/cookbooks/travis_ci_mega/attributes/default.rb
+++ b/cookbooks/travis_ci_mega/attributes/default.rb
@@ -133,3 +133,18 @@ override['rabbitmq']['enabled_plugins'] = %w(rabbitmq_management)
 
 override['travis_build_environment']['update_hostname'] = false
 override['travis_build_environment']['use_tmpfs_for_builds'] = false
+
+override['travis_packer_templates']['job_board']['languages'] = %w(
+  c
+  cpp
+  clojure
+  go
+  groovy
+  java
+  node_js
+  python
+  ruby
+  rust
+  scala
+)
+override['travis_packer_templates']['job_board']['edge'] = true

--- a/cookbooks/travis_ci_mega/recipes/default.rb
+++ b/cookbooks/travis_ci_mega/recipes/default.rb
@@ -22,7 +22,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-execute 'apt-get update -yqq'
+include_recipe 'travis_packer_templates'
 
 package Array(node['travis_ci_mega']['prerequisite_packages']) do
   action [:install, :upgrade]

--- a/cookbooks/travis_ci_minimal/attributes/default.rb
+++ b/cookbooks/travis_ci_minimal/attributes/default.rb
@@ -147,3 +147,6 @@ override['travis_build_environment']['packages'] = %w(
   zip
   zlib1g-dev
 )
+
+override['travis_packer_templates']['job_board']['languages'] = %w(generic)
+override['travis_packer_templates']['job_board']['edge'] = true

--- a/cookbooks/travis_ci_minimal/recipes/default.rb
+++ b/cookbooks/travis_ci_minimal/recipes/default.rb
@@ -22,8 +22,7 @@
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-execute 'apt-get update -yqq'
-
+include_recipe 'travis_packer_templates'
 include_recipe 'travis_build_environment'
 include_recipe 'apt'
 

--- a/cookbooks/travis_packer_templates/attributes/default.rb
+++ b/cookbooks/travis_packer_templates/attributes/default.rb
@@ -9,3 +9,6 @@ default['travis_packer_templates']['env']['PACKER_BUILDER_TYPE'] = ''
 
   default['travis_packer_templates']['env'][attr_name] = attr_value
 end
+
+default['travis_packer_templates']['job_board']['languages'] = []
+default['travis_packer_templates']['job_board']['edge'] = false

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -30,7 +30,7 @@ template '/etc/default/job-board-register' do
   group 'root'
   mode 0644
   variables(
-    languages: node['travis_packer_templates']['job_board']['languages']
+    languages: node['travis_packer_templates']['job_board']['languages'],
     edge: node['travis_packer_templates']['job_board']['edge']
   )
 end

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -1,1 +1,36 @@
-# nobody home
+# Cookbook Name:: travis_packer_templates
+# Recipe:: default
+#
+# Copyright 2015, Travis CI GmbH
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+execute 'apt-get update -yqq'
+
+template '/etc/default/job-board-register' do
+  source 'etc-default-job-board-register.erb'
+  owner 'root'
+  group 'root'
+  mode 0644
+  variables(
+    languages: node['travis_packer_templates']['job_board']['languages']
+    edge: node['travis_packer_templates']['job_board']['edge']
+  )
+end

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -25,7 +25,7 @@
 execute 'apt-get update -yqq'
 
 template '/etc/default/job-board-register' do
-  source 'etc-default-job-board-register.erb'
+  source 'etc-default-job-board-register.sh.erb'
   owner 'root'
   group 'root'
   mode 0644

--- a/cookbooks/travis_packer_templates/templates/default/etc-default-job-board-register.erb
+++ b/cookbooks/travis_packer_templates/templates/default/etc-default-job-board-register.erb
@@ -1,0 +1,11 @@
+# vim:filetype=sh
+# Managed by Chef! :heart_eyes_cat:
+
+TAGS=""
+<% if @edge %>
+TAGS="$TAGS,group:edge"
+<% end %>
+<% @languages.each do |lang| %>
+TAGS="$TAGS,language_${lang}:true"
+<% end %>
+export TAGS

--- a/cookbooks/travis_packer_templates/templates/default/etc-default-job-board-register.sh.erb
+++ b/cookbooks/travis_packer_templates/templates/default/etc-default-job-board-register.sh.erb
@@ -1,4 +1,3 @@
-# vim:filetype=sh
 # Managed by Chef! :heart_eyes_cat:
 
 TAGS=""
@@ -6,6 +5,6 @@ TAGS=""
 TAGS="$TAGS,group:edge"
 <% end %>
 <% @languages.each do |lang| %>
-TAGS="$TAGS,language_${lang}:true"
+TAGS="$TAGS,language_<%= lang %>:true"
 <% end %>
 export TAGS

--- a/packer-scripts/job-board-register
+++ b/packer-scripts/job-board-register
@@ -2,6 +2,10 @@
 
 set -o errexit
 
+if [[ -f /etc/default/job-board-register ]] ; then
+  source /etc/default/job-board-register
+fi
+
 [[ $JOB_BOARD_IMAGES_URL ]] || {
   echo Missing \$JOB_BOARD_IMAGES_URL
   exit 1
@@ -29,6 +33,10 @@ if [[ $PACKER_BUILDER_TYPE ]] ; then
 fi
 
 : ${IMAGE_INFRA:=local}
+
+echo "time=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+     "msg=\"registering with job board\"" \
+     "name=${IMAGE_NAME} infra=${IMAGE_INFRA} tags=${TAGS}"
 
 exec curl \
   -s \


### PR DESCRIPTION
which should result in images being automatically available via `group: edge`
after successful builds.