### PR TITLE
Defer writing job-board-register vars

### DIFF
--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -61,6 +61,7 @@ ruby_block 'write job-board-register metadata' do
       '/etc/default/job-board-register', run_context
     )
     template.source 'etc-default-job-board-register.sh.erb'
+    template.cookbook 'travis_packer_templates'
     template.owner 'root'
     template.group 'root'
     template.mode 0644

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -57,7 +57,9 @@ end
 
 ruby_block 'write job-board-register metadata' do
   block do
-    template = Chef::Resource::Template.new('/etc/default/job-board-register')
+    template = Chef::Resource::Template.new(
+      '/etc/default/job-board-register', run_context
+    )
     template.source 'etc-default-job-board-register.sh.erb'
     template.owner 'root'
     template.group 'root'

--- a/cookbooks/travis_packer_templates/recipes/default.rb
+++ b/cookbooks/travis_packer_templates/recipes/default.rb
@@ -55,17 +55,21 @@ ruby_block 'set system_info.cookbooks_sha' do
   end
 end
 
-template '/etc/default/job-board-register' do
-  source 'etc-default-job-board-register.sh.erb'
-  owner 'root'
-  group 'root'
-  mode 0644
-  variables(
-    dist: node['travis_packer_templates']['job_board']['dist'],
-    group: node['travis_packer_templates']['job_board']['group'],
-    branch: node['travis_packer_templates']['env']['PACKER_TEMPLATES_BRANCH'],
-    languages: node['travis_packer_templates']['job_board']['languages']
-  )
+ruby_block 'write job-board-register metadata' do
+  block do
+    template = Chef::Resource::Template.new('/etc/default/job-board-register')
+    template.source 'etc-default-job-board-register.sh.erb'
+    template.owner 'root'
+    template.group 'root'
+    template.mode 0644
+    template.variables(
+      dist: node['travis_packer_templates']['job_board']['dist'],
+      group: node['travis_packer_templates']['job_board']['group'],
+      branch: node['travis_packer_templates']['env']['PACKER_TEMPLATES_BRANCH'],
+      languages: node['travis_packer_templates']['job_board']['languages']
+    )
+    template.run_action(:create)
+  end
 end
 
 ruby_block 'set travis_packer_templates.packages from ' \

--- a/packer-scripts/cleanup
+++ b/packer-scripts/cleanup
@@ -4,18 +4,19 @@ set -o errexit
 set -o xtrace
 
 rm -rf \
-  VBoxGuestAdditions_*.iso \
-  VBoxGuestAdditions_*.iso.? \
+  /etc/apparmor* \
+  /etc/ssh/ssh_host_* \
+  /etc/systemd \
+  /lib/recovery-mode \
   /opt/chef \
   /tmp/packer* \
-  /var/log/installer \
-  /var/lib/man-db \
+  /var/chef \
   /var/lib/apt/lists/* \
+  /var/lib/man-db \
+  /var/log/installer \
   /var/tmp/* \
-  /etc/ssh/ssh_host_* \
-  /etc/apparmor* \
-  /etc/systemd \
-  /lib/recovery-mode
+  VBoxGuestAdditions_*.iso \
+  VBoxGuestAdditions_*.iso.?
 
 if [[ -d /home/travis ]] ; then
   rm -f /home/travis/linux.iso /home/travis/shutdown.sh


### PR DESCRIPTION
until they've been properly dynamically defined.